### PR TITLE
Hide sub-menu except on hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,23 @@ ul.menu>li.current>a {
   font: 1.2rem "Montserrat-Bold", sans-serif;
 }
 
+.nav-child {
+  display: none;
+}
+
+.menu li:hover .nav-child {
+  display: block;
+  position: fixed;
+  background-color: #fff;
+  border: 1px solid black;
+  padding: 0.5em;
+  text-transform: uppercase;
+}
+
+.menu li:hover .nav-child a {
+  color: black;
+}
+
 .site {
   display: flex;
   min-height: 100vh;


### PR DESCRIPTION
Hide sub menus in the main menu except when hovering over the menu item. Probably still needs work, but this is one way of doing it in pure css.
