### PR TITLE
remove visited links color change

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,10 +28,6 @@ h1>a:focus, h2>a:focus, h3>a:focus, h4>a:focus, h5>a:focus{
   color: black;
 }
 
-h1>a:visited, h2>a:visited, h3>a:visited, h4>a:visited {
-  color: #444444;
-}
-
 h1 {
   font-size: 1.4em;
 }


### PR DESCRIPTION
Changing visited links color breaks color change on hover for visited links. I find the hover color feature much more important than visited link color feature, and therefore suggest removing this. I am sure it's possible to have both features working, but this is a quick fix since I don't know CSS well.
